### PR TITLE
add workflow for Update Gradle Wrapper Action

### DIFF
--- a/.github/workflows/Android-CI-Espresso.yml
+++ b/.github/workflows/Android-CI-Espresso.yml
@@ -40,7 +40,7 @@ jobs:
           tag: default
           abi: x86
       - name: Archive Espresso results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
           name: Logcat-Espresso-report
@@ -71,7 +71,7 @@ jobs:
       - name: gradle check
         run: ./gradlew check
       - name: Archive Lint report
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
           name: Logcat-Lint-report


### PR DESCRIPTION
This action keeps Gradle Wrapper up-to-date to the latest release. It
will run every day at midnight (UTC) and create a pull request if a new
Gradle version is available. The updated Wrapper script is validated
(with checksum verification) during the update process, and the Wrapper
is setup so that it will validate the Gradle binary itself on first run
of the new version.