### PR TITLE
showLogContent() must always be called

### DIFF
--- a/LogcatCoreLib/src/main/java/info/hannes/logcat/base/LogBaseFragment.kt
+++ b/LogcatCoreLib/src/main/java/info/hannes/logcat/base/LogBaseFragment.kt
@@ -55,9 +55,7 @@ abstract class LogBaseFragment : Fragment() {
 
         setFilter2LogAdapter("")
 
-        if (savedInstanceState == null) {
-            showLogContent()
-        }
+        showLogContent()
 
         setHasOptionsMenu(true)
 


### PR DESCRIPTION
fixes no log entries loaded when activity is recreated, tested with dev option, don't keep activities