### PR TITLE
Set minimum width equal to parent

### DIFF
--- a/LogcatCoreLib/build.gradle
+++ b/LogcatCoreLib/build.gradle
@@ -16,6 +16,7 @@ android {
 }
 
 dependencies {
+    implementation "androidx.core:core-ktx:1.3.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"

--- a/LogcatCoreLib/src/main/java/info/hannes/logcat/base/LogBaseFragment.kt
+++ b/LogcatCoreLib/src/main/java/info/hannes/logcat/base/LogBaseFragment.kt
@@ -12,6 +12,7 @@ import android.view.*
 import android.widget.CompoundButton
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.FileProvider
+import androidx.core.view.doOnLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.coroutineScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -50,6 +51,11 @@ abstract class LogBaseFragment : Fragment() {
             it.layoutManager = LinearLayoutManager(it.context)
             it.recycledViewPool.setMaxRecycledViews(R.layout.item_log, DEFAULT_MAX_SCRAP)
         }
+
+        logsRecycler?.doOnLayout {
+            it.minimumWidth = (it.parent as ViewGroup).width
+        }
+
         // empty adapter to avoid "E/RecyclerView﹕ No adapter attached; skipping layou..."
         logListAdapter = LogListAdapter(mutableListOf(), currentFilter).also {
             it.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY


### PR DESCRIPTION
We have dynamic width (wrapping contents of variable widths) and if log entries are short or if you change device orientation to landscape, our width may be smaller than parent