### PR TITLE
Subclass fix: Move non constants out of companion object

### DIFF
--- a/LogcatCoreLib/src/main/java/info/hannes/logcat/LogfileFragment.kt
+++ b/LogcatCoreLib/src/main/java/info/hannes/logcat/LogfileFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import info.hannes.logcat.base.LogBaseFragment
-import info.hannes.timber.FileLoggingTree
 import info.hannes.timber.fileLoggingTree
 import java.io.File
 
@@ -16,7 +15,7 @@ class LogfileFragment : LogBaseFragment(), Observer<Event<String>> {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = super.onCreateView(inflater, container, savedInstanceState)
-        FileLoggingTree.lastLogEntry.observe(viewLifecycleOwner, this)
+        fileLoggingTree()?.lastLogEntry?.observe(viewLifecycleOwner, this)
         return view
     }
 

--- a/LogcatCoreLib/src/main/java/info/hannes/timber/FileLoggingTree.kt
+++ b/LogcatCoreLib/src/main/java/info/hannes/timber/FileLoggingTree.kt
@@ -20,6 +20,13 @@ open class FileLoggingTree(externalCacheDir: File, context: Context? = null, fil
     var file: File
         private set
 
+    val lastLogEntry: LiveData<Event<String>>
+        get() = _lastLogEntry
+
+    protected val _lastLogEntry = MutableLiveData<Event<String>>()
+
+    private var logImpossible = false
+
     init {
         if (!externalCacheDir.exists()) {
             if (!externalCacheDir.mkdirs())
@@ -76,9 +83,5 @@ open class FileLoggingTree(externalCacheDir: File, context: Context? = null, fil
     companion object {
 
         private val LOG_TAG = FileLoggingTree::class.java.simpleName
-        private var logImpossible = false
-        protected val _lastLogEntry = MutableLiveData<Event<String>>()
-        val lastLogEntry: LiveData<Event<String>>
-            get() = _lastLogEntry
     }
 }


### PR DESCRIPTION
Last time, I failed to test properly in my own project, sorry about that, my last commit did not have the effect intended in subclass, (fixes: `Using non-JVM static members protected in the superclass companion is unsupported yet`)