### PR TITLE
Fix malformed json

### DIFF
--- a/LogcatCoreLib/src/main/java/info/hannes/timber/DebugTree.kt
+++ b/LogcatCoreLib/src/main/java/info/hannes/timber/DebugTree.kt
@@ -21,8 +21,8 @@ open class DebugTree : Timber.DebugTree() {
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
         var localMessage = message.trim()
         if (localMessage.startsWith("{") && localMessage.endsWith("}")) {
-            val json = JSONObject(message)
             try {
+                val json = JSONObject(message)
                 localMessage = json.toString(3)
             } catch (e: JSONException) {
             }


### PR DESCRIPTION
It can run into `org.json.JSONException: Expected ':' after init at character 6 of {init}`