### PR TITLE
Use new logcat

### DIFF
--- a/LogcatCoreLib/src/main/java/info/hannes/timber/DebugFormatTree.kt
+++ b/LogcatCoreLib/src/main/java/info/hannes/timber/DebugFormatTree.kt
@@ -4,17 +4,33 @@ import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
 
-open class DebugFormatTree : Timber.DebugTree() {
+/* If you use old logcat, e.g Android Studio Electric Eel, you should use for newLogcat a false */
+open class DebugFormatTree(private val newLogcat: Boolean = true) : Timber.DebugTree() {
+
+    private var codeIdentifier = ""
 
     override fun createStackElementTag(element: StackTraceElement): String? {
-        return String.format(
-            "(%s:%d) %s.%s()",
-            element.fileName,
-            element.lineNumber, // format ensures line numbers have at least 3 places to align consecutive output from the same file
-            // method is fully qualified only when class differs on filename otherwise it can be cropped on long lambda expressions
-            super.createStackElementTag(element)?.replaceFirst(element.fileName.takeWhile { it != '.' }, ""),
-            element.methodName
-        )
+        if (newLogcat) {
+            codeIdentifier = String.format(
+                "(%s:%d)",
+                element.fileName,
+                element.lineNumber // format ensures line numbers have at least 3 places to align consecutive output from the same file
+            )
+            return String.format(
+                "%s.%s()",
+                // method is fully qualified only when class differs on filename otherwise it can be cropped on long lambda expressions
+                super.createStackElementTag(element)?.replaceFirst(element.fileName.takeWhile { it != '.' }, ""),
+                element.methodName
+            )
+        } else
+            return String.format(
+                "(%s:%d) %s.%s()",
+                element.fileName,
+                element.lineNumber, // format ensures line numbers have at least 3 places to align consecutive output from the same file
+                // method is fully qualified only when class differs on filename otherwise it can be cropped on long lambda expressions
+                super.createStackElementTag(element)?.replaceFirst(element.fileName.takeWhile { it != '.' }, ""),
+                element.methodName
+            )
     }
 
     // if there is an JSON string, try to print out pretty
@@ -24,9 +40,11 @@ open class DebugFormatTree : Timber.DebugTree() {
             try {
                 val json = JSONObject(message)
                 localMessage = json.toString(3)
-            } catch (e: JSONException) {
+            } catch (_: JSONException) {
             }
         }
+        if (newLogcat)
+            localMessage = codeIdentifier + localMessage
         super.log(priority, tag, localMessage, t)
     }
 }


### PR DESCRIPTION
With Android Studio Giraffe the new logcat is mandatory, but there you loose the click on code feature on given tag, so it moved to logged text