### PR TITLE
Rename parameter

### DIFF
--- a/LogcatCoreLib/src/main/java/info/hannes/logcat/Event.kt
+++ b/LogcatCoreLib/src/main/java/info/hannes/logcat/Event.kt
@@ -55,8 +55,8 @@ open class Event<out T>(private val content: T) {
 @Suppress("unused")
 class EventObserver<T>(private val onEventUnhandledContent: (T) -> Unit) : Observer<Event<T>> {
 
-    override fun onChanged(event: Event<T>) {
-        event.getContentIfNotHandled()?.let {
+    override fun onChanged(value: Event<T>) {
+        value.getContentIfNotHandled()?.let {
             onEventUnhandledContent(it)
         }
     }


### PR DESCRIPTION
This avoid this message:
The corresponding parameter in the supertype 'Observer' is named 'value'. This may cause problems when calling this function with named arguments