### PR TITLE
Remove Countly warning

### DIFF
--- a/LogcatCountlyLib/src/main/java/info/hannes/countly/Analytics.kt
+++ b/LogcatCountlyLib/src/main/java/info/hannes/countly/Analytics.kt
@@ -77,7 +77,7 @@ class Analytics : IAnalytics {
                     .setLoggingEnabled(loggingEnabled)
                     .enableAutomaticViewTracking()
                     .setHttpPostForced(true)
-                    .enableCrashReporting()
+            config.crashes.enableCrashReporting()
             Countly.sharedInstance().init(config)
         }
     }


### PR DESCRIPTION
this call is deprecated, please use crashes.enableCrashReporting() instead