### PR TITLE
Remove publish warning

### DIFF
--- a/LogcatCoreLib/build.gradle
+++ b/LogcatCoreLib/build.gradle
@@ -20,6 +20,9 @@ android {
     buildFeatures {
         buildConfig true
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 dependencies {

--- a/LogcatCoreUI/build.gradle
+++ b/LogcatCoreUI/build.gradle
@@ -21,7 +21,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 dependencies {

--- a/LogcatCountlyLib/build.gradle
+++ b/LogcatCountlyLib/build.gradle
@@ -15,7 +15,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 dependencies {

--- a/LogcatCrashlyticLib/build.gradle
+++ b/LogcatCrashlyticLib/build.gradle
@@ -16,7 +16,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 dependencies {


### PR DESCRIPTION
```
w: ⚠️ Android Publication 'release' Misconfigured for Variant 'release' Android Publication 'release' for variant 'release' was not configured properly:

To avoid this warning, please create and configure Android publication variant with name 'release'. Example:
android {
    publishing {
        singleVariant("release") {}
    }
}
Solution:
Please configure Android publication 'release' for variant 'release'. See https://kotl.in/oe70nr for more details.
```