### PR TITLE
Change JDK distribution to 'temurin' in workflow

### DIFF
--- a/.github/workflows/Android-CI-Espresso.yml
+++ b/.github/workflows/Android-CI-Espresso.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java_version }}
       - name: kvm support
         run: |
@@ -97,7 +97,7 @@ jobs:
       - name: Install JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java_version }}
       - name: gradle check
         run: ./gradlew check


### PR DESCRIPTION
Updated JDK distribution from 'adopt' to 'temurin' in CI workflow.